### PR TITLE
dtype coercion

### DIFF
--- a/downstream/dataframe/_explode_lookup_packed.py
+++ b/downstream/dataframe/_explode_lookup_packed.py
@@ -10,9 +10,12 @@ def explode_lookup_packed(
     df: pl.DataFrame,
     *,
     value_type: typing.Literal["hex", "uint64", "uint32", "uint16", "uint8"],
+    result_schema: typing.Literal["coerce", "relax", "shrink"] = "coerce",
 ) -> pl.DataFrame:
     """Explode downstream-curated data from hexidecimal serialization of
     downstream buffers and counters to one-data-item-per-row, applying
     downstream lookup to identify origin time `Tbar` of each item."""
-    df = unpack_data_packed(df)
-    return explode_lookup_unpacked(df, value_type=value_type)
+    df = unpack_data_packed(df, result_schema=result_schema)
+    return explode_lookup_unpacked(
+        df, result_schema=result_schema, value_type=value_type
+    )

--- a/downstream/dataframe/_explode_lookup_unpacked.py
+++ b/downstream/dataframe/_explode_lookup_unpacked.py
@@ -52,7 +52,7 @@ def _check_bitwidths(df: pl.DataFrame) -> None:
         raise NotImplementedError("Value bitwidth > 64 not yet supported")
     if (
         not df.lazy()
-        .filter(pl.col("dstream_value_bitwidth").is_in([2, 3]))
+        .filter(pl.col("dstream_value_bitwidth").cast(pl.UInt32).is_in([2, 3]))
         .limit(1)
         .collect()
         .is_empty()
@@ -68,24 +68,24 @@ def _check_bitwidths(df: pl.DataFrame) -> None:
         raise NotImplementedError("Multiple value bitwidths not yet supported")
 
 
-def _get_value_type(value_type: str) -> pl.DataType:
+def _get_value_dtype(value_type: str) -> pl.DataType:
     """Convert value_type string arg to Polars DataType object."""
-    value_type = {
+    value_dtype = {
         "hex": "hex",
         "uint64": pl.UInt64,
         "uint32": pl.UInt32,
         "uint16": pl.UInt16,
         "uint8": pl.UInt8,
     }.get(value_type, None)
-    if value_type is None:
+    if value_dtype is None:
         raise ValueError("Invalid value_type")
-    elif value_type == "hex":
-        raise NotImplementedError("Hex value_type not yet supported")
+    elif value_dtype == "hex":
+        raise NotImplementedError("hex value_type not yet supported")
 
-    return value_type
+    return value_dtype
 
 
-def _make_empty(value_type: pl.DataType) -> pl.DataFrame:
+def _make_empty(value_dtype: pl.DataType) -> pl.DataFrame:
     """Create an empty DataFrame with the expected columns for
     unpack_data_packed, handling edge case of empty input."""
     return pl.DataFrame(
@@ -95,7 +95,7 @@ def _make_empty(value_type: pl.DataType) -> pl.DataFrame:
             pl.Series(name="dstream_S", values=[], dtype=pl.UInt32),
             pl.Series(name="dstream_Tbar", values=[], dtype=pl.UInt64),
             pl.Series(name="dstream_T", values=[], dtype=pl.UInt64),
-            pl.Series(name="dstream_value", values=[], dtype=value_type),
+            pl.Series(name="dstream_value", values=[], dtype=value_dtype),
             pl.Series(
                 name="dstream_value_bitwidth", values=[], dtype=pl.UInt32
             ),
@@ -107,7 +107,7 @@ def explode_lookup_unpacked(
     df: pl.DataFrame,
     *,
     value_type: typing.Literal["hex", "uint64", "uint32", "uint16", "uint8"],
-    relax_dtypes: bool = False
+    result_schema: typing.Literal["coerce", "relax", "shrink"] = "coerce",
 ) -> pl.DataFrame:
     """Explode downstream-curated data from one-buffer-per-row (with each
     buffer containing multiple data items) to one-data-item-per-row, applying
@@ -146,9 +146,11 @@ def explode_lookup_unpacked(
 
         Note that 'hex' is not yet supported.
 
-    relax_dtypes : bool = False
-        If set to True, calls `shrink_dtype()` on all columns before the
-        final DataFrame is returned, thereby saving memory.
+    result_schema : Literal['coerce', 'relax', 'shrink'], default 'coerce'
+        How should dtypes in the output DataFrame be handled?
+        - 'coerce' : cast all columns to output schema.
+        - 'relax' : keep all columns as-is.
+        - 'shrink' : cast columns to smallest possible types.
 
     Returns
     -------
@@ -159,7 +161,7 @@ def explode_lookup_unpacked(
         Output schema:
 
         - 'dstream_data_id' : pl.UInt64
-            - Row index dentifier of dstream buffer that data item is from.
+            - Row index identifier of dstream buffer that data item is from.
         - 'dstream_Tbar' : pl.UInt64
             - Logical position of data item in stream (number of prior data
               items).
@@ -194,7 +196,7 @@ def explode_lookup_unpacked(
         function.
     """
     _check_df(df)
-    value_dtype = _get_value_type(value_type)
+    value_dtype = _get_value_dtype(value_type)
 
     if df.lazy().limit(1).collect().is_empty():
         return _make_empty(value_dtype)
@@ -224,7 +226,7 @@ def explode_lookup_unpacked(
         dstream_value_bitwidth=np.right_shift(
             pl.col("dstream_storage_hex").str.len_bytes() * 4,
             int(dstream_S).bit_length() - 1,
-        ).cast(pl.UInt32),
+        ),
     )
 
     _check_bitwidths(df)
@@ -253,14 +255,7 @@ def explode_lookup_unpacked(
     logging.info(" - looking up ingest times...")
 
     lookup_op = dstream_algo.lookup_ingest_times_batched
-    dstream_T = (
-        df.lazy()
-        .select("dstream_T")
-        .cast(pl.UInt64)
-        .collect()
-        .to_numpy()
-        .ravel()
-    )
+    dstream_T = df.lazy().select("dstream_T").collect().to_numpy().ravel()
     df_long = (
         df_long.with_columns(
             dstream_Tbar=pl.Series(
@@ -272,8 +267,23 @@ def explode_lookup_unpacked(
         .collect()
     )
 
-    if relax_dtypes:
-        return df_long.select(pl.all().shrink_dtype())
+    logging.info(" - finalizing result schema")
+    try:
+        df_long = {
+            "coerce": lambda df: df.cast(
+                {
+                    "dstream_data_id": pl.UInt64,
+                    "dstream_Tbar": pl.UInt64,
+                    "dstream_T": pl.UInt64,
+                    "dstream_value": value_dtype,
+                    "dstream_value_bitwidth": pl.UInt32,
+                },
+            ),
+            "relax": lambda df: df,
+            "shrink": lambda df: df.select(pl.all().shrink_dtype()),
+        }[result_schema](df_long)
+    except KeyError:
+        raise ValueError(f"Invalid arg {result_schema} for result_schema")
 
     logging.info("explode_lookup_unpacked complete")
     return df_long

--- a/downstream/dataframe/_unpack_data_packed.py
+++ b/downstream/dataframe/_unpack_data_packed.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 
 import numpy as np
 import polars as pl
@@ -55,7 +56,9 @@ def _make_empty() -> pl.DataFrame:
 
 
 def unpack_data_packed(
-    df: pl.DataFrame, *, relax_dtypes: bool = False
+    df: pl.DataFrame,
+    *,
+    result_schema: typing.Literal["coerce", "relax", "shrink"] = "coerce",
 ) -> pl.DataFrame:
     """Unpack data with dstream buffer and counter serialized into a single
     hexadecimal data field.
@@ -81,16 +84,18 @@ def unpack_data_packed(
                 - Position of dstream counter field in 'data_hex'.
             - 'dstream_T_bitwidth' : pl.UInt64
                 - Size of dstream counter field in 'data_hex'.
-            - 'dstream_S' : pl.Uint32
+            - 'dstream_S' : pl.UInt32
                 - Capacity of dstream buffer, in number of data items.
 
         Optional schema:
             - 'downstream_version' : pl.Categorical
                 - Version of downstream library used to curate data items.
 
-    relax_dtypes : bool = False
-        If set to True, calls `shrink_dtype()` on all columns before the
-        final DataFrame is returned, thereby saving memory.
+    result_schema : Literal['coerce', 'relax', 'shrink'], default 'coerce'
+        How should dtypes in the output DataFrame be handled?
+        - 'coerce' : cast all columns to output schema.
+        - 'relax' : keep all columns as-is.
+        - 'shrink' : cast columns to smallest possible types.
 
     Returns
     -------
@@ -104,7 +109,7 @@ def unpack_data_packed(
                 - e.g., 'dstream.steady_algo'
             - 'dstream_data_id' : pl.UInt64
                 - Row index identifier for dstream buffer.
-            - 'dstream_S' : pl.Uint32
+            - 'dstream_S' : pl.UInt32
                 - Capacity of dstream buffer, in number of data items.
             - 'dstream_T' : pl.UInt64
                 - Logical time elapsed (number of elapsed data items in stream).
@@ -167,8 +172,7 @@ def unpack_data_packed(
                 pl.col("dstream_T_hexoffset"),
                 length=pl.col("dstream_T_hexwidth"),
             )
-            .str.to_integer(base=16)
-            .cast(pl.Uint64),
+            .str.to_integer(base=16),
         )
         .drop(
             [
@@ -186,8 +190,22 @@ def unpack_data_packed(
         .collect()
     )
 
-    if relax_dtypes:
-        return df.select(pl.all().shrink_dtype())
+    logging.info(" - finalizing result schema")
+    try:
+        df = {
+            "coerce": lambda df: df.cast(
+                {
+                    "dstream_data_id": pl.UInt64,
+                    "dstream_S": pl.UInt32,
+                    "dstream_T": pl.UInt64,
+                    "dstream_storage_hex": pl.String,
+                },
+            ),
+            "relax": lambda df: df,
+            "shrink": lambda df: df.select(pl.all().shrink_dtype()),
+        }[result_schema](df)
+    except KeyError:
+        raise ValueError(f"Invalid arg {result_schema} for result_schema")
 
     logging.info("unpack_data_packed complete")
     return df


### PR DESCRIPTION
This PR forces datatypes in the functions in `downstream.dataframe` to be coerced according to the stated output schema, with the option of relaxing the datatypes to save memory if need be.