### PR TITLE
Add Zig usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,53 @@ downstream provides efficient, constant-space implementations of stream curation
 -   Free software: MIT license
 -   Documentation: <https://mmore500.github.io/downstream>
 
+## Installation
+
+Zig downstream is packaged as a source module and CLI. Clone this repository and
+build with `zig build`.  The resulting executable will be available at
+`./zig-out/bin/downstream`.
+
+To embed downstream into another project, add it as a module within your own
+`build.zig` script, e.g.
+
+```zig
+const downstream = b.addModule("downstream", .{ .root_source_file =
+    b.path("path/to/downstream/src/main.zig") });
+```
+
+## API Reference
+
+See the [Python quickstart](https://mmore500.github.io/downstream/quickstart) for
+outline and intuition.
+
+Each algorithm variant is accessible through its own namespace:
+
+* Steady: `downstream.dstream.steady_algo`
+* Stretched: `downstream.dstream.stretched_algo`
+* Tilted: `downstream.dstream.tilted_algo`
+
+See [selecting a dstream algorithm](https://mmore500.github.io/downstream/algorithm)
+for more information.
+
+#### `has_ingest_capacity`
+```zig
+pub fn has_ingest_capacity(comptime u: type, S: u, T: u) bool
+```
+Determines if there is capacity to ingest a data item at logical time `T`.
+
+* `S`: Current site capacity
+* `T`: Logical time of data item
+
+#### `assign_storage_site`
+```zig
+pub fn assign_storage_site(comptime u: type, S: u, T: u) u
+```
+Site selection algorithm for steady curation. Returns selected site or `S` if
+data should be discarded.
+
+* `S`: Current site capacity
+* `T`: Logical time of data item
+
 ## Citing
 
 If downstream contributes to a scientific publication, please cite it as


### PR DESCRIPTION
## Summary
- describe how to build and import the Zig module
- list namespaces and API for `has_ingest_capacity` and `assign_storage_site`

## Testing
- `bash test/test.sh` *(fails: `zig` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851eaac05f083229fbcd77e560031ab