### PR TITLE
Make Crates.io badge clickable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [
 ![PyPi](https://img.shields.io/pypi/v/downstream.svg)
 ](https://pypi.python.org/pypi/downstream)
-![Crates.io](https://img.shields.io/crates/v/downstream)
+[![Crates.io](https://img.shields.io/crates/v/downstream)](https://crates.io/crates/downstream)
 [![DOI](https://zenodo.org/badge/776865597.svg)](https://zenodo.org/doi/10.5281/zenodo.10866541)
 <!-- [![Documentation Status](https://readthedocs.org/projects/downstream/badge/?version=latest)](https://downstream.readthedocs.io/en/latest/?badge=latest) -->
 <!-- [![documentation coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fmmore500.github.io%2Fdownstream%2Fdocumentation-coverage-badge.json)](https://downstream.readthedocs.io/en/latest/) -->


### PR DESCRIPTION
## Summary
Updated the Crates.io badge in the README to be a clickable link, consistent with the PyPI badge formatting.

## Changes
- Wrapped the Crates.io badge image with a markdown link to https://crates.io/crates/downstream
- This makes the badge interactive, allowing users to click through to the Crates.io package page
- Maintains consistency with the existing PyPI badge which already had this functionality

## Details
The change converts the badge from a plain image to a linked image using standard markdown syntax: `[![alt](image-url)](link-url)`. This improves user experience by making the badge a direct navigation element to the package registry.

https://claude.ai/code/session_01Ghe1E6cfvyvcDYn6vgYcp9