### PR TITLE
Pin downstream version in README installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ downstream provides efficient, constant-space implementations of stream curation
 
 To install from PyPi with pip, run
 
-`python3 -m pip install "downstream[jit]"`
+`python3 -m pip install "downstream[jit]==1.22.0"`
 
 A containerized release of `downstream` is available via <https://ghcr.io>
 

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -9,3 +9,6 @@ push = true
 "CITATION.cff" = [
     'cff-version: {pep440_version}',
 ]
+"README.md" = [
+    'downstream[jit]=={pep440_version}',
+]


### PR DESCRIPTION
## Summary
Updated the README installation instructions to include a specific version pin for the downstream package, and configured bumpver to automatically update this version during releases.

## Key Changes
- Updated the pip install command in README.md to pin `downstream[jit]` to version `1.22.0` instead of using the unpinned specification
- Added a new bumpver configuration rule for README.md to automatically update the pinned version string during version bumps using the `{pep440_version}` placeholder

## Details
This change ensures that:
1. Users following the README installation instructions get a known, tested version of the package
2. The version pin in the README will be automatically kept in sync with releases through the bumpver configuration, preventing documentation drift

https://claude.ai/code/session_018KjsBN15nJu2ofkAqtgEYR